### PR TITLE
feat(sticky-directive): add marginTop input

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ If a boundary element is defined, the sticky element scrolls only within the hei
 
 The spacer is not required but prevents a page jump when the sticky effect steps in.
 
+#### Margin top
+
+A `marginTop` (default `0`) input can be used to add some top spacing to the sticky element, in case you don't want it to stick right at the top. It expects the `number` of pixels you want to use for the space. You can [take a look at the examples](https://w11k.github.io/angular-sticky-things/).
+
+```html
+<div #boundary style="height:1000px;">
+  <div #spacer></div>
+  <div stickyThing [spacer]="spacer" marginTop="30">
+    I leave 30px of space to the top when I'm sticky!
+  </div>
+</div>
+```
+
 ## Patron
 
 ❤️ [W11K - The Web Engineers](https://www.w11k.de/)

--- a/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
+++ b/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
@@ -33,6 +33,7 @@ export interface StickyStatus {
 export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
 
 
+  @Input() marginTop = 0;
   @Input('spacer') spacerElement: HTMLElement | undefined;
   @Input('boundary') boundaryElement: HTMLElement | undefined;
 
@@ -130,7 +131,7 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
 
   private determineStatus(originalVals: StickyPositions, pageYOffset: number): StickyStatus {
     const stickyElementHeight = this.getComputedStyle(this.stickyElement.nativeElement).height;
-    const reachedLowerEdge = this.boundaryElement && window.pageYOffset + stickyElementHeight >= originalVals.bottomBoundary;
+    const reachedLowerEdge = this.boundaryElement && window.pageYOffset + stickyElementHeight >= (originalVals.bottomBoundary - this.marginTop);
     return {
       isSticky: pageYOffset > originalVals.offsetY,
       reachedLowerEdge
@@ -155,16 +156,15 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
       bottomBoundary = boundaryElementHeight + boundaryElementOffset;
     }
 
-    return {offsetY: getPosition(this.stickyElement.nativeElement).y, bottomBoundary};
+    return {offsetY: (getPosition(this.stickyElement.nativeElement).y - this.marginTop), bottomBoundary};
   }
 
   private makeSticky(boundaryReached: boolean = false): void {
 
     this.boundaryReached = boundaryReached;
-
     // do this before setting it to pos:fixed
     const {width, height, left} = this.getComputedStyle(this.stickyElement.nativeElement);
-    const offSet = boundaryReached ? (this.getComputedStyle(this.boundaryElement).bottom - this.getComputedStyle(this.stickyElement.nativeElement).height) : 0;
+    const offSet = boundaryReached ? (this.getComputedStyle(this.boundaryElement).bottom - height) : this.marginTop;
 
     this.sticky = true;
     this.stickyElement.nativeElement.style.position = 'fixed';

--- a/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
+++ b/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
@@ -162,6 +162,7 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
   private makeSticky(boundaryReached: boolean = false): void {
 
     this.boundaryReached = boundaryReached;
+
     // do this before setting it to pos:fixed
     const {width, height, left} = this.getComputedStyle(this.stickyElement.nativeElement);
     const offSet = boundaryReached ? (this.getComputedStyle(this.boundaryElement).bottom - height) : this.marginTop;

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -58,7 +58,7 @@
     <div class="row">
       <div class="col-6">
         <div #spacer3></div>
-        <div stickyThing="" [spacer]="spacer3" [boundary]="boundary3">
+        <div stickyThing="" [spacer]="spacer3" [boundary]="boundary3" marginTop="50">
           <svg xmlns="http://www.w3.org/2000/svg" width="210mm" height="155mm"
                viewBox="0 0 210 155">
             <path


### PR DESCRIPTION
Added a `marginTop` input that can be used to add some top space to the sticky element.